### PR TITLE
Add `--force-yes`

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -42,7 +42,7 @@ apt-get $APT_OPTIONS update | indent
 
 for PACKAGE in $(cat $BUILD_DIR/Aptfile); do
   topic "Fetching .debs for $PACKAGE"
-  apt-get $APT_OPTIONS -y -d install $PACKAGE | indent
+  apt-get $APT_OPTIONS -y --force-yes -d install $PACKAGE | indent
 done
 
 mkdir -p $BUILD_DIR/.apt


### PR DESCRIPTION
Sometimes there are problems:

WARNING: The following packages cannot be authenticated!
         debhelper
E: There are problems and -y was used without --force-yes
