### PR TITLE
libVips / slugbuilder support

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -61,7 +61,7 @@ export LIBRARY_PATH="\$HOME/.apt/usr/lib/x86_64-linux-gnu:\$HOME/.apt/usr/lib/i3
 export INCLUDE_PATH="\$HOME/.apt/usr/include:\$INCLUDE_PATH"
 export CPATH="\$INCLUDE_PATH"
 export CPPPATH="\$INCLUDE_PATH"
-export PKG_CONFIG_PATH="\$HOME/.apt/usr/lib/x86_64-linux-gnu/pkgconfig:\$HOME/.apt/usr/lib/i386-linux-gnu/pkgconfig:\$PKG_CONFIG_PATH"
+export PKG_CONFIG_PATH="\$HOME/.apt/usr/lib/x86_64-linux-gnu/pkgconfig:\$HOME/.apt/usr/lib/i386-linux-gnu/pkgconfig:\$HOME/.apt/usr/lib/pkgconfig:\$PKG_CONFIG_PATH"
 EOF
 
 export PATH="$BUILD_DIR/.apt/usr/bin:$PATH"
@@ -70,4 +70,4 @@ export LIBRARY_PATH="$BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu:$BUILD_DIR/.apt/us
 export INCLUDE_PATH="$BUILD_DIR/.apt/usr/include:$INCLUDE_PATH"
 export CPATH="$INCLUDE_PATH"
 export CPPPATH="$INCLUDE_PATH"
-export PKG_CONFIG_PATH="$BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu/pkgconfig:$BUILD_DIR/.apt/usr/lib/i386-linux-gnu/pkgconfig:$PKG_CONFIG_PATH"
+export PKG_CONFIG_PATH="$BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu/pkgconfig:$BUILD_DIR/.apt/usr/lib/i386-linux-gnu/pkgconfig:$BUILD_DIR/.apt/usr/lib/pkgconfig:$PKG_CONFIG_PATH"


### PR DESCRIPTION
I do not know much about Apt, but the following changes seem to work, and without these changes certain things are impossible.
- Packages like libvips [have their compiled libraries under `/usr/lib/:architecture`](https://packages.debian.org/sid/i386/libvips-dev/filelist) instead of just `/usr/lib`.
  - This seems to affect `LD_LIBRARY_PATH` and `LIBRARY_PATH`
- Certain gems like `ruby-vips` need pkg-config to work in order to compile native extensions, which in turn require it to be defined.
  - While this variable seems to be defined in Cedar 14, Apt-specific directories were not listed
- Certain packages like libpango, libpangocairo and libpangoft2 all need to be compiled in the same way; as Cedar 14 already has one of them, without the `--reinstall` flag the artifacts will conflict.
  - See https://github.com/evadne/heroku-buildpack-apt/commit/4d898d55ea952ccb3962daf291bdf248644275d0

Please consider this pull request. Thanks again.
