### PR TITLE
Add x86_64-linux-gnu subdirectory to INCLUDE_PATH

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -37,6 +37,9 @@ mkdir -p "$APT_STATE_DIR/lists/partial"
 
 APT_OPTIONS="-o debug::nolocking=true -o dir::cache=$APT_CACHE_DIR -o dir::state=$APT_STATE_DIR"
 
+topic "Cleaning apt caches"
+apt-get $APT_OPTIONS clean | indent
+
 topic "Updating apt caches"
 apt-get $APT_OPTIONS update | indent
 

--- a/bin/compile
+++ b/bin/compile
@@ -52,7 +52,7 @@ for PACKAGE in $(cat $BUILD_DIR/Aptfile); do
     curl -s -L -z $PACKAGE_FILE -o $PACKAGE_FILE $PACKAGE 2>&1 | indent
   else
     topic "Fetching .debs for $PACKAGE"
-    apt-get $APT_OPTIONS -y --force-yes -d install --reinstall $PACKAGE | indent
+    apt-get $APT_OPTIONS -y --force-yes --no-install-recommends -d install --reinstall $PACKAGE | indent
   fi
 done
 

--- a/bin/compile
+++ b/bin/compile
@@ -78,7 +78,7 @@ EOF
 export PATH="$BUILD_DIR/.apt/usr/bin:$PATH"
 export LD_LIBRARY_PATH="$BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu:$BUILD_DIR/.apt/usr/lib/i386-linux-gnu:$BUILD_DIR/.apt/usr/lib:$LD_LIBRARY_PATH"
 export LIBRARY_PATH="$BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu:$BUILD_DIR/.apt/usr/lib/i386-linux-gnu:$BUILD_DIR/.apt/usr/lib:$LIBRARY_PATH"
-export INCLUDE_PATH="$BUILD_DIR/.apt/usr/include:$INCLUDE_PATH"
+export INCLUDE_PATH="$BUILD_DIR/.apt/usr/include/x86_64-linux-gnu:$BUILD_DIR/.apt/usr/include:$INCLUDE_PATH"
 export CPATH="$INCLUDE_PATH"
 export CPPPATH="$INCLUDE_PATH"
 export PKG_CONFIG_PATH="$BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu/pkgconfig:$BUILD_DIR/.apt/usr/lib/i386-linux-gnu/pkgconfig:$BUILD_DIR/.apt/usr/lib/pkgconfig:$PKG_CONFIG_PATH"


### PR DESCRIPTION
Looks like the newer Ubuntu multiarch subdirectories had already been added to the other exported paths, but not for INCLUDE_PATH. This commit makes it consistent.