### PR TITLE
Add additional sources using Sourcesfile

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -37,6 +37,13 @@ mkdir -p "$APT_STATE_DIR/lists/partial"
 
 APT_OPTIONS="-o debug::nolocking=true -o dir::cache=$APT_CACHE_DIR -o dir::state=$APT_STATE_DIR"
 
+if [ -f $BUILD_DIR/Sourcesfile ]; then
+  topic "Adding sources"
+
+  cat /etc/apt/sources.list $BUILD_DIR/Sourcesfile > $BUILD_DIR/sources.list
+  APT_OPTIONS="$APT_OPTIONS -o dir::etc::sourcelist=$BUILD_DIR/sources.list"
+fi
+
 topic "Updating apt caches"
 apt-get $APT_OPTIONS update | indent
 


### PR DESCRIPTION
Add additional apt sources using `Sourcesfile`. We use it for adding multiverse repositories.