### PR TITLE
Add PIP_GLOBAL_OPTIONS to the exports

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -82,4 +82,4 @@ export PIP_GLOBAL_OPTION="build_ext -I/app/.apt/usr/include -L/app/.apt/usr/lib"
 export PKG_CONFIG_PATH="$BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu/pkgconfig:$BUILD_DIR/.apt/usr/lib/i386-linux-gnu/pkgconfig:$BUILD_DIR/.apt/usr/lib/pkgconfig:$PKG_CONFIG_PATH"
 
 #give environment to later buildpacks
-export | grep -E -e ' (PATH|LD_LIBRARY_PATH|LIBRARY_PATH|INCLUDE_PATH|CPATH|CPPPATH|PKG_CONFIG_PATH)='  > "$LP_DIR/export"
+export | grep -E -e ' (PATH|LD_LIBRARY_PATH|LIBRARY_PATH|INCLUDE_PATH|CPATH|CPPPATH|PKG_CONFIG_PATH|PIP_GLOBAL_OPTION)='  > "$LP_DIR/export"

--- a/bin/compile
+++ b/bin/compile
@@ -78,6 +78,7 @@ export LIBRARY_PATH="$BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu:$BUILD_DIR/.apt/us
 export INCLUDE_PATH="$BUILD_DIR/.apt/usr/include:$INCLUDE_PATH"
 export CPATH="$INCLUDE_PATH"
 export CPPPATH="$INCLUDE_PATH"
+export PIP_GLOBAL_OPTION="build_ext -I/app/.apt/usr/include -L/app/.apt/usr/lib"
 export PKG_CONFIG_PATH="$BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu/pkgconfig:$BUILD_DIR/.apt/usr/lib/i386-linux-gnu/pkgconfig:$BUILD_DIR/.apt/usr/lib/pkgconfig:$PKG_CONFIG_PATH"
 
 #give environment to later buildpacks

--- a/bin/compile
+++ b/bin/compile
@@ -79,7 +79,7 @@ export INCLUDE_PATH="$BUILD_DIR/.apt/usr/include:$INCLUDE_PATH"
 export CPATH="$INCLUDE_PATH"
 export CPPPATH="$INCLUDE_PATH"
 export PIP_GLOBAL_OPTION="build_ext -I/app/.apt/usr/include -L/app/.apt/usr/lib"
-export PYTHONPATH="$BUILD_DIR/.apt/usr/lib/python2.7site-packages:$PYTHONPATH"
+export PYTHONPATH="$BUILD_DIR/.apt/usr/lib/python2.7/dist-packages:$PYTHONPATH"
 export PKG_CONFIG_PATH="$BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu/pkgconfig:$BUILD_DIR/.apt/usr/lib/i386-linux-gnu/pkgconfig:$BUILD_DIR/.apt/usr/lib/pkgconfig:$PKG_CONFIG_PATH"
 
 #give environment to later buildpacks

--- a/bin/compile
+++ b/bin/compile
@@ -79,6 +79,7 @@ export INCLUDE_PATH="$BUILD_DIR/.apt/usr/include:$INCLUDE_PATH"
 export CPATH="$INCLUDE_PATH"
 export CPPPATH="$INCLUDE_PATH"
 export PIP_GLOBAL_OPTION="build_ext -I/app/.apt/usr/include -L/app/.apt/usr/lib"
+export PYTHONPATH="$BUILD_DIR/.apt/usr/lib/python2.7site-packages:$PYTHONPATH"
 export PKG_CONFIG_PATH="$BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu/pkgconfig:$BUILD_DIR/.apt/usr/lib/i386-linux-gnu/pkgconfig:$BUILD_DIR/.apt/usr/lib/pkgconfig:$PKG_CONFIG_PATH"
 
 #give environment to later buildpacks


### PR DESCRIPTION
This makes things just work (at least for the things I have tried) with the heroku-python-buildpack when there are compile-time dependencies.